### PR TITLE
[MAIB-88] - Add-secondary-info-card

### DIFF
--- a/components/SecondaryInfoCard/SecondaryInfoCard.module.scss
+++ b/components/SecondaryInfoCard/SecondaryInfoCard.module.scss
@@ -1,0 +1,74 @@
+.secondaryInfoCard {
+  position: relative;
+  display: flex;
+
+  width: 620px;
+  height: 264px;
+
+  overflow: hidden;
+  border-radius: 10px;
+  padding: 32px;
+
+  &:hover {
+    .image {
+      animation: scale-up 0.3s ease-in-out both;
+    }
+  }
+
+  .media {
+    &::after {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      content: " ";
+      background: linear-gradient(
+        180deg,
+        rgba(0, 0, 0, 0) 0%,
+        rgba(0, 0, 0, 0.5) 58.75%,
+        rgba(0, 0, 0, 0.8) 75.36%,
+        #000000 100%
+      );
+    }
+  }
+
+  .content {
+    position: relative;
+    align-self: flex-end;
+
+    .header {
+      font: var(--heading-3);
+      margin: 0;
+      padding-bottom: 16px;
+      color: var(--white);
+    }
+
+    .date {
+      font: var(--body-large);
+      color: var(--gray-500);
+    }
+  }
+
+  .action {
+    color: transparent;
+
+    &::after {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      content: " ";
+    }
+  }
+}
+
+@keyframes scale-up {
+  0% {
+    transform: scale(1);
+  }
+  100% {
+    transform: scale(1.25);
+  }
+}

--- a/components/SecondaryInfoCard/index.tsx
+++ b/components/SecondaryInfoCard/index.tsx
@@ -1,0 +1,38 @@
+import Image from "next/image";
+import Link from "next/link";
+import styles from "./SecondaryInfoCard.module.scss";
+
+type AppProps = {
+  media: {
+    src: string;
+    alt: string;
+  };
+  title: string;
+  date: string;
+  href: string;
+};
+
+const SecondaryInfoCard = ({ media, title, date, href }: AppProps) => {
+  return (
+    <article className={styles.secondaryInfoCard}>
+      <span className={styles.media}>
+        <Image
+          className={styles.image}
+          alt={media.alt}
+          src={media.src}
+          layout="fill"
+          objectFit="cover"
+        />
+      </span>
+      <div className={styles.content}>
+        <h3 className={styles.header}>{title}</h3>
+        <time className={styles.date}>{date}</time>
+      </div>
+      <Link href={href}>
+        <a className={styles.action}>Try it now</a>
+      </Link>
+    </article>
+  );
+};
+
+export default SecondaryInfoCard;

--- a/components/index.tsx
+++ b/components/index.tsx
@@ -1,4 +1,5 @@
 import Button from "./button";
 import HijriDate from "./HijriDate";
+import SecondaryInfoCard from "./SecondaryInfoCard";
 
-export { Button, HijriDate };
+export { Button, HijriDate, SecondaryInfoCard };


### PR DESCRIPTION
## What's this PR do ? ⭐️
Add secondary card component

```jsx
<SecondaryInfoCard
  title="Amalan rezeki yang harus dijaga bagi umat islam"
  date="28 Mei 2022"
  href="amalan-rezeki-yang-harus-dijaga-bagi-umat-islam"
  media={{
    src: "https://source.unsplash.com/random?islam",
    alt: "Random image from unsplash",
  }}
/>
```

Has 98% similarity with `<MainInfoCard/>` #7 . The only difference is the card height and the name.

## What are the relevant ticket ? ⭐️

[MAIB-88](https://gteam.atlassian.net/browse/MAIB-88)

## Any deployment note (migrations, new envs, rake tasks, cron) ?

## Definition of Done:

-   [ ] Does this PR introduces a breaking change ?

-   [x] Does this PR passes Lint locally ?

-   [ ] Does this PR requires Database changes ?

-   [ ] Does this PR requires a regression test by QA ?

-   [ ] Does this PR adds new dependencies ? (network setup, new 3rd party services)

## Screenshots (if appropriate)
![d](https://user-images.githubusercontent.com/73181490/171165700-70216ca1-a647-46a9-9dab-0d1f5b1152b1.gif)

